### PR TITLE
Extend RepoHandler to inherit AdoptDefaults and accept optional repo branch overrides

### DIFF
--- a/src/common/RepoHandler.groovy
+++ b/src/common/RepoHandler.groovy
@@ -21,15 +21,25 @@ class RepoHandler {
     private final Map ADOPT_DEFAULTS_JSON
     private Map USER_DEFAULTS_JSON
 
-    private final String ADOPT_JENKINS_DEFAULTS_URL = "https://raw.githubusercontent.com/adoptium/ci-jenkins-pipelines/master/pipelines/defaults.json"
+    private final String ADOPT_JENKINS_DEFAULTS_MASTER_URL = "https://raw.githubusercontent.com/adoptium/ci-jenkins-pipelines/master/pipelines/defaults.json"
 
     /*
-    Constructor
+    Constructor: Adopt defaults from ADOPT_JENKINS_DEFAULTS_MASTER_URL
     */
     RepoHandler (Map<String, ?> configs) {
         this.configs = configs
 
         def getAdopt = new URL(ADOPT_JENKINS_DEFAULTS_URL).openConnection()
+        this.ADOPT_DEFAULTS_JSON = new JsonSlurper().parseText(getAdopt.getInputStream().getText()) as Map
+    }
+
+    /*
+    Constructor: Adopt defaults from caller
+    */
+    RepoHandler (Map<String, ?> configs, String adoptJenkinsDefaultsUrl) {
+        this.configs = configs
+
+        def getAdopt = new URL(adoptJenkinsDefaultsUrl).openConnection()
         this.ADOPT_DEFAULTS_JSON = new JsonSlurper().parseText(getAdopt.getInputStream().getText()) as Map
     }
 


### PR DESCRIPTION
To resolve the issue around build release pipelines from build script branches, or the scenario of doing a personal build from a tag, the RepoHandler needs knowledge of the build config override branches.

This PR adds a new constructor to allow the override branches to be specified.

This forms a prereq to PR fix: https://github.com/adoptium/ci-jenkins-pipelines/pull/604/files
