### PR TITLE
Stop adding NODE_LABEL to build job parameters

### DIFF
--- a/src/common/IndividualBuildConfig.groovy
+++ b/src/common/IndividualBuildConfig.groovy
@@ -205,7 +205,6 @@ class IndividualBuildConfig implements Serializable {
     List<?> toBuildParams() {
         List<?> buildParams = []
 
-        buildParams.add(['$class': 'LabelParameterValue', name: 'NODE_LABEL', label: NODE_LABEL])
         buildParams.add(['$class': 'TextParameterValue', name: 'BUILD_CONFIGURATION', value: toJson()])
 
         return buildParams


### PR DESCRIPTION
Fixes: https://github.com/adoptium/infrastructure/issues/2774#issuecomment-1494192694
