### PR TITLE
Remove NODE_LABEL from build job params

### DIFF
--- a/src/common/IndividualBuildConfig.groovy
+++ b/src/common/IndividualBuildConfig.groovy
@@ -205,7 +205,6 @@ class IndividualBuildConfig implements Serializable {
     List<?> toBuildParams() {
         List<?> buildParams = []
 
-        buildParams.add(['$class': 'LabelParameterValue', name: 'NODE_LABEL', label: NODE_LABEL])
         buildParams.add(['$class': 'TextParameterValue', name: 'BUILD_CONFIGURATION', value: toJson()])
 
         return buildParams


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/312

Issue https://github.com/adoptium/ci-jenkins-pipelines/pull/101/files originally remove the NODE_LABEL from the create build job template, as it is correctly not needed, since the openjdk pipelines use node() context to achieve the same here: https://github.com/adoptium/ci-jenkins-pipelines/blob/bc206dcf5aab5ebba3f081a55533c9313fc5cefb/pipelines/build/common/openjdk_build_pipeline.groovy

However the jenkins-helper IndividualBuildConfig.toBuildParams() was still adding it to the job invocation, thus causing the Jenkins log error...
