### PR TITLE
Security: Enable SSL Signature Checks

### DIFF
--- a/Jenkins_jobs/CreateNewNode.groovy
+++ b/Jenkins_jobs/CreateNewNode.groovy
@@ -29,7 +29,7 @@ node {
                 println "Machine: '${machines[index]}' already exists."
             } else {
                 if (Integer.parseInt(machineIPs[index].split("\\.")[0]) == 10) {
-                    launcher = new CommandLauncher(Constants.SSH_COMMAND + "${machineIPs[index]} " + "\"wget -q --no-check-certificate -O slave.jar ${JENKINS_URL}jnlpJars/slave.jar ; java -jar slave.jar\"");
+                    launcher = new CommandLauncher(Constants.SSH_COMMAND + "${machineIPs[index]} " + "\"wget -q -O slave.jar ${JENKINS_URL}jnlpJars/slave.jar ; java -jar slave.jar\"");
                     remoteFS = Constants.REMOTE_FS;
                 } else if (machines[index].contains("win")) {
                     launcher = new JNLPLauncher("", "", new jenkins.slaves.RemotingWorkDirSettings(false, "", "remoting", false));


### PR DESCRIPTION
Remove disabled signature checks for download of Jenkins slave.jar from HTTPs served jenkins server.

Fixes https://github.com/adoptium/infrastructure/issues/3342

Identified in Trail Of Bits Security Audit: TOB-9