### PR TITLE
Remove master from code-freeze and fix release branch regex

### DIFF
--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -3,7 +3,7 @@ name: Code Freeze Bot
 # Controls when the workflow will run
 on:
   pull_request_target:
-    branches: [ "master", "v[0-9]{4}.[0-9]{2}.[0-9]{2}" ]
+    branches: [ "v[0-9]+.[0-9]+.[0-9]+" ]
   issue_comment:
     types: [created]
 

--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -9,6 +9,5 @@ on:
 
 jobs:
   codefreeze:
-    permissions: read-all
     uses: adoptium/.github/.github/workflows/code-freeze.yml@main
     secrets: inherit

--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -9,5 +9,6 @@ on:
 
 jobs:
   codefreeze:
+    permissions: read-all
     uses: adoptium/.github/.github/workflows/code-freeze.yml@main
     secrets: inherit


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/3703
As per PMC discussion, "master" branch removed from freeze
And corrected (confirmed this works on temurin-build repo) the release branch freezing